### PR TITLE
✨ Refactor and add support for triggering with workflow dispatch events

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -6,6 +6,11 @@ on:
       - main
     types:
       - closed
+  workflow_dispatch:
+    inputs:
+      number:
+        description: PR number to use when running this GitHub Action.
+        required: true
 
 jobs:
   latest-changes:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ on:
       # Or use the branch "master" if that's your main branch:
       # - master
     types:
-      # This action should only run after the PR has been merged
       - closed
 
 jobs:
@@ -29,8 +28,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker://tiangolo/latest-changes:0.0.1
-      # You can also use the action directly, but that will take about an extra minute:
-      # - tiangolo/latest-changes:0.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Note**: you can also use the GitHub action directly intead of with Docker, but that would take an extra minute:
+
+```YAML
+      # - uses: docker://tiangolo/latest-changes:0.0.1
+      # This is slower but also works
+      - uses: tiangolo/latest-changes:0.0.1
 ```
 
 In this minimal example, it uses all the default configurations.
@@ -111,6 +118,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: tiangolo/latest-changes:0.0.1
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         latest_changes_file: docs/release-notes.md
         latest_changes_header: '# Release Notes\n\n'
         template_file: ./.github/workflows/release-notes.jinja2

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ description: Update the release notes with the "latest changes" right after a PR
 inputs:
   token:
     description: Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}
+    required: true
+  number:
+    description: Optional PR number to call this GitHub Action manually in a workflow.
     required: false
   latest_changes_file:
     description: The file to add the latest changes

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -20,7 +20,8 @@ class Settings(BaseSettings):
     github_repository: str
     github_event_path: Path
     github_event_name: Optional[str] = None
-    input_token: Optional[SecretStr] = None
+    input_token: SecretStr
+    input_number: Optional[int] = None
     input_latest_changes_file: Path = Path("README.md")
     input_latest_changes_header: str = "### Latest Changes\n\n"
     input_template_file: Path = Path(__file__).parent / "latest-changes.jinja2"
@@ -42,55 +43,59 @@ logging.basicConfig(level=logging.INFO)
 settings = Settings()
 if settings.input_debug_logs:
     logging.info(f"Using config: {settings.json()}")
-# TODO: This might be useful later for parsing a comment in the PR
-# g = Github(settings.input_token.get_secret_value())
-# repo = g.get_repo(settings.github_repository)
-# owner: NamedUser = repo.owner
-# github_event: Optional[GitHubEventPullRequest] = None
-if settings.github_event_path.is_file():
+g = Github(settings.input_token.get_secret_value())
+repo = g.get_repo(settings.github_repository)
+event: Optional[GitHubEventPullRequest] = None
+number: Optional[int] = settings.input_number
+if settings.input_number is None and settings.github_event_path.is_file():
     contents = settings.github_event_path.read_text()
-    github_event = GitHubEventPullRequest.parse_raw(contents)
-    if settings.input_debug_logs:
-        logging.info("GitHub Event object:")
-        debug(github_event)
-        logging.info(f"GitHub Event JSON: {github_event.json(indent=2)}")
-    if not github_event.pull_request.merged:
-        logging.error(
-            "The PR was not merged but this action was run, add a step to your GitHub Action with:"
-        )
-        logging.error("if: github.event.pull_request.merged == true")
-        sys.exit(1)
-    if not settings.input_latest_changes_file.is_file():
-        logging.error(
-            f"The latest changes files doesn't seem to exist: {settings.input_latest_changes_file}"
-        )
-        sys.exit(1)
-    logging.info("Setting up GitHub Actions git user")
-    subprocess.run(["git", "config", "user.name", "github-actions"], check=True)
-    subprocess.run(
-        ["git", "config", "user.email", "github-actions@github.com"], check=True
+    event = GitHubEventPullRequest.parse_raw(contents)
+    number = event.pull_request.number
+if number is None:
+    logging.error("This GitHub action must be triggered by a merged PR or with a PR number")
+    sys.exit(1)
+assert number is not None, "The PR number should exist by now"
+pr = repo.get_pull(number)
+if settings.input_debug_logs:
+    logging.info("PR object:")
+    debug(pr)
+if not pr.merged:
+    logging.error(
+        "The PR was not merged but this action was run, add a step to your GitHub Action with:"
     )
-    logging.info(
-        "Pulling the latest changes, including the latest merged PR (this one)"
+    logging.error("if: github.event.pull_request.merged == true")
+    sys.exit(1)
+if not settings.input_latest_changes_file.is_file():
+    logging.error(
+        f"The latest changes files doesn't seem to exist: {settings.input_latest_changes_file}"
     )
-    subprocess.run(["git", "pull"], check=True)
-    content = settings.input_latest_changes_file.read_text()
-    match = re.search(settings.input_latest_changes_header, content)
-    if not match:
-        logging.error(
-            f"The latest changes file at: {settings.input_latest_changes_file} doesn't seem to contain the header RegEx: {settings.input_latest_changes_header}"
-        )
-        sys.exit(1)
-    pre_content = content[: match.end()]
-    post_content = content[match.end() :]
-    template_content = settings.input_template_file.read_text("utf-8")
-    template = Template(template_content)
-    message = template.render(github_event=github_event)
-    new_content = pre_content + message + post_content
-    settings.input_latest_changes_file.write_text(new_content)
-    logging.info(f"Committing changes to: {settings.input_latest_changes_file}")
-    subprocess.run(["git", "add", str(settings.input_latest_changes_file)], check=True)
-    subprocess.run(["git", "commit", "-m", "📝 Update release notes"], check=True)
-    logging.info(f"Pushing changes: {settings.input_latest_changes_file}")
-    subprocess.run(["git", "push"], check=True)
+    sys.exit(1)
+logging.info("Setting up GitHub Actions git user")
+subprocess.run(["git", "config", "user.name", "github-actions"], check=True)
+subprocess.run(
+    ["git", "config", "user.email", "github-actions@github.com"], check=True
+)
+logging.info(
+    "Pulling the latest changes, including the latest merged PR (this one)"
+)
+subprocess.run(["git", "pull"], check=True)
+content = settings.input_latest_changes_file.read_text()
+match = re.search(settings.input_latest_changes_header, content)
+if not match:
+    logging.error(
+        f"The latest changes file at: {settings.input_latest_changes_file} doesn't seem to contain the header RegEx: {settings.input_latest_changes_header}"
+    )
+    sys.exit(1)
+pre_content = content[: match.end()]
+post_content = content[match.end() :]
+template_content = settings.input_template_file.read_text("utf-8")
+template = Template(template_content)
+message = template.render(pr=pr)
+new_content = pre_content + message + post_content
+settings.input_latest_changes_file.write_text(new_content)
+logging.info(f"Committing changes to: {settings.input_latest_changes_file}")
+subprocess.run(["git", "add", str(settings.input_latest_changes_file)], check=True)
+subprocess.run(["git", "commit", "-m", "📝 Update release notes"], check=True)
+logging.info(f"Pushing changes: {settings.input_latest_changes_file}")
+subprocess.run(["git", "push"], check=True)
 logging.info("Finished")

--- a/app/latest-changes.jinja2
+++ b/app/latest-changes.jinja2
@@ -1,2 +1,2 @@
-* {{github_event.pull_request.title}}. PR [#{{github_event.pull_request.number}}]({{github_event.pull_request.html_url}}) by [@{{github_event.pull_request.user.login}}]({{github_event.pull_request.user.html_url}}).
+* {{pr.title}}. PR [#{{pr.number}}]({{pr.html_url}}) by [@{{pr.user.login}}]({{pr.user.html_url}}).
 


### PR DESCRIPTION
✨ Refactor and add support for triggering with workflow dispatch events.

---

For this action to work, the workflow has to be on the repo _before_ the PR that is being merged was created, so that the commit merging the PR already has the workflow, even though it actually runs on the main branch.

The main thing I want from it is to help me save time adding "latest changes" for already existing PRs.

Another option would be to rebase before merging, but that's not always possible.

This update should allow enabling a `workflow dispatch`, to trigger the action _manually_ with a PR number right after merging. In those cases, it won't be as great as everything happening automatically (as for PRs created after the workflow is added), but it will still save some steps and human errors by only needing the PR number.

And it seems there's no way around it with the current available GitHub Actions events.