### PR TITLE
🚀 Publish amd64 and arm64 versions, and publish to GitHub Container Registry, fix git in containers

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -31,6 +31,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             tiangolo/latest-changes:latest
             ghcr.io/tiangolo/latest-changes:latest
@@ -39,6 +40,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             tiangolo/latest-changes:${{ github.event.release.tag_name }}
             ghcr.io/tiangolo/latest-changes:${{ github.event.release.tag_name }}

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      # TODO: remove this
+      - ghcr
   release:
     types:
       - published
@@ -19,14 +21,24 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: tiangolo/latest-changes:latest
+          tags: |
+            tiangolo/latest-changes:latest
+            ghcr.io/tiangolo/latest-changes:latest
       - name: Build and push tag
         if: github.event_name == 'release'
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: tiangolo/latest-changes:${{ github.event.release.tag_name }}
+          tags: |
+            tiangolo/latest-changes:${{ github.event.release.tag_name }}
+            ghcr.io/tiangolo/latest-changes:${{ github.event.release.tag_name }}

--- a/latest_changes/__main__.py
+++ b/latest_changes/__main__.py
@@ -31,6 +31,11 @@ class PartialGitHubEvent(BaseModel):
 
 
 logging.basicConfig(level=logging.INFO)
+# Ref: https://github.com/actions/runner/issues/2033
+logging.info("GitHub Actions workaround for git in containers, ref: https://github.com/actions/runner/issues/2033")
+safe_directory_config_content = "[safe]\n\tdirectory = /github/workspace"
+dotgitconfig_path = Path.home() / ".gitconfig"
+dotgitconfig_path.write_text(safe_directory_config_content)
 settings = Settings()
 if settings.input_debug_logs:
     logging.info(f"Using config: {settings.json()}")


### PR DESCRIPTION
🚀 Publish amd64 and arm64 versions, and publish to GitHub Container Registry, fix git in containers

The original intention was that I expected pulling from GitHub Container Registry in other GitHub Actions to be faster, but it was roughly the same as pulling from Docker Hub, so no big difference.