### PR TITLE
♻️ Refactor usage of internal `number_of_trials` variable, it was not being used, fix typo

### DIFF
--- a/latest_changes/main.py
+++ b/latest_changes/main.py
@@ -229,7 +229,7 @@ def main() -> None:
     )
     number_of_trials = 10
     logging.info(f"Number of trials (for race conditions): {number_of_trials}")
-    for trial in range(10):
+    for trial in range(number_of_trials):
         logging.info(f"Running trial: {trial}")
         logging.info(
             "Pulling the latest changes, including the latest merged PR (this one)"

--- a/latest_changes/model.py
+++ b/latest_changes/model.py
@@ -3214,7 +3214,7 @@ class WorkflowRun(BaseModel):
     head_branch: str = Field(..., example='master')
     head_sha: str = Field(
         ...,
-        description='The SHA of the head commit that points to the version of the worflow being run.',
+        description='The SHA of the head commit that points to the version of the workflow being run.',
         example='009b8a3a9ccbb128af87f9b1c0f4c62e8a304f6d',
     )
     run_number: int = Field(


### PR DESCRIPTION
1. Fix the typo "worflow" to "workflow" in README.md.
2. Use the `number_of_trials` variable in the for loop to improve consistency and maintainability in the file latest_changes/main.py.