### PR TITLE
✨ Prevent CI workflows from running on a latest changes commit, add `[skip ci]` to commit message

### DIFF
--- a/latest_changes/main.py
+++ b/latest_changes/main.py
@@ -11,6 +11,11 @@ from jinja2 import Template
 from pydantic import BaseModel, SecretStr
 from pydantic_settings import BaseSettings
 
+COMMIT_MESSAGE = """
+📝 Update release notes
+
+[skip ci]
+""".strip()
 
 class Section(BaseModel):
     label: str
@@ -248,7 +253,7 @@ def main() -> None:
         subprocess.run(
             ["git", "add", str(settings.input_latest_changes_file)], check=True
         )
-        subprocess.run(["git", "commit", "-m", "📝 Update release notes"], check=True)
+        subprocess.run(["git", "commit", "-m", COMMIT_MESSAGE], check=True)
         logging.info(f"Pushing changes: {settings.input_latest_changes_file}")
 
         result = subprocess.run(["git", "push"])


### PR DESCRIPTION
This will prevent ci being run on commits from latest-changes.

See: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs