### PR TITLE
🔧 Update GitHub Actions bot user configuration

### DIFF
--- a/latest_changes/main.py
+++ b/latest_changes/main.py
@@ -228,9 +228,9 @@ def main() -> None:
         sys.exit(1)
 
     logging.info("Setting up GitHub Actions git user")
-    subprocess.run(["git", "config", "user.name", "github-actions"], check=True)
+    subprocess.run(["git", "config", "user.name", "github-actions[bot]"], check=True)
     subprocess.run(
-        ["git", "config", "user.email", "github-actions@github.com"], check=True
+        ["git", "config", "user.email", "github-actions[bot]@users.noreply.github.com"], check=True
     )
     number_of_trials = 10
     logging.info(f"Number of trials (for race conditions): {number_of_trials}")


### PR DESCRIPTION
This PR configures git user to match the expected standard by Github (check [this discussion](https://github.com/orgs/community/discussions/160496)).

Currently, commits from this action are shown as "invalid-email-address" in github insights, this PR should fix it.