### PR TITLE
👷 Update setup-python pin comment to 6.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: ".python-version"
       - name: Set up uv


### PR DESCRIPTION
## Changes

Updates `actions/setup-python` hash-pin comments from `v6` to `v6.2.0` where the pinned commit is `a309ff8b426b58ec0e2a45f0f869d46889d02405`.

## Validation

- Verified the pinned hash resolves to `actions/setup-python` tag `v6.2.0`.
- Verified no stale `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6` entries remain in the updated workflow files.

## AI Disclaimer

Using Codex with GPT-5. Reviewed manually.
