### PR TITLE
🐛 Run action on its baked-in Python instead of `uv run`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,6 @@ COPY ./latest_changes /app/latest_changes
 
 ENV PYTHONPATH=/app
 
-CMD ["uv", "run", "python", "-m", "latest_changes"]
+# Use the image's baked-in venv directly. `uv run` would execute in the mounted
+# consumer repo and pick up its `.python-version`, provisioning a Python we don't ship.
+CMD ["/app/.venv/bin/python", "-m", "latest_changes"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ RUN uv sync --locked
 
 COPY ./latest_changes /app/latest_changes
 
-ENV PYTHONPATH=/app
+ENV PYTHONPATH=/app \
+    PATH="/app/.venv/bin:$PATH"
 
-# Use the image's baked-in venv directly. `uv run` would execute in the mounted
-# consumer repo and pick up its `.python-version`, provisioning a Python we don't ship.
-CMD ["/app/.venv/bin/python", "-m", "latest_changes"]
+# Put the image's baked-in venv first on PATH. `uv run` would execute in the
+# mounted consumer repo and pick up its `.python-version`, provisioning a Python
+# we don't ship.
+CMD ["python", "-m", "latest_changes"]


### PR DESCRIPTION
## Description

After upgrading `tiangolo/latest-changes` to 0.0.6 in https://github.com/fastapi/fastapi-cli and https://github.com/fastapi/typer/ the `latest-changes` workflow started to fail with:

```
error: No interpreter found for Python 3.10 in managed installations or search path

hint: A managed Python download is available for Python 3.10, but Python downloads are set to 'never'
```

See: [logs](https://github.com/fastapi/typer/actions/runs/28613446812/job/84851327965)


Investigated this with the help of Claude Code and it turned out that the culprit is `uv run` in
```
CMD ["uv", "run", "python", "-m", "latest_changes"]
```
that uses the version of Python from `uv.lock` or `.python-version` of the repository that runs action (GitHub overrides workdir when runs the container of GH action).

So, if the repo has `3.10` in `.python-version`, `uv run` command attempts to install Python 3.10 and fails due to `UV_PYTHON_DOWNLOADS=0`


## AI Disclaimer

Fix is generated by Claude Opus 4.8 (1M context), then I:
* carefully reviewed the changes
* tested fixed action in my test repository (ran action from the branch of this PR - `YuriiMotov/latest-changes@fix/run-action-on-baked-python`)

## Checklist

- [ ] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
