### PR TITLE
🐛 Align defaults with standalone release notes

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -31,10 +31,6 @@ jobs:
       - uses: ./
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          latest_changes_file: release-notes.md
-          latest_changes_header: '## Latest Changes'
-          end_regex: '^## .*'
-          label_header_prefix: '### '
           debug_logs: true
     # - name: Secure tmate session
     #   run: curl https://github.com/tiangolo.keys > ~/.tmate_authorized_keys && echo 'set tmate-authorized-keys "~/.tmate_authorized_keys"' > ~/.xtmate.conf

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ After merging a PR to the main branch, it will:
 * Inside of that file, find a "header" with the text:
 
 ```Markdown
-### Latest Changes
+## Latest Changes
 ```
 
 * Right after that, it will add a new list item with the changes:
@@ -65,7 +65,7 @@ After merging a PR to the main branch, it will:
 
 It will look something like:
 
-> ### Latest Changes
+> ## Latest Changes
 >
 > * ✨ Add support for Jinja2 templates for latest changes messages. PR [#23](https://github.com/tiangolo/latest-changes/pull/23) by [@tiangolo](https://github.com/tiangolo).
 
@@ -94,13 +94,13 @@ By default, it will use these labels and headers:
 
 So, if you have a PR with a label `feature`, by default, it will show up in the section about features, like:
 
-> ### Latest Changes
+> ## Latest Changes
 >
-> #### Features
+> ### Features
 >
 > * ✨ Add support for Jinja2 templates for latest changes messages. PR [#23](https://github.com/tiangolo/latest-changes/pull/23) by [@tiangolo](https://github.com/tiangolo).
 
-You can configure the labels and headers used in the GitHub Action `labels` workflow configuration, and you can configure the header prefix, by default `#### `.
+You can configure the labels and headers used in the GitHub Action `labels` workflow configuration, and you can configure the header prefix, by default `### `.
 
 You can also configure labels that should be skipped, those PRs won't be added to the release notes.
 
@@ -131,10 +131,10 @@ You can configure:
 * `latest_changes_file`: The file to modify with the latest changes. By default, the action searches for `release-notes.md`, `docs/release-notes.md`, and `docs/en/docs/release-notes.md`, in that order. For example, you can override it with `./docs/latest-changes.rst`.
 * `latest_changes_header`: The header to look for before adding a new message. for example: `# CHANGELOG`.
 * `template_file`: A custom Jinja2 template file to use to generate the message, you could use this to generate a different message or to use a different format, for example, HTML instead of the default Markdown.
-* `end_regex`: A RegEx string that marks the end of this release, so it normally matches the start of the header of the next release section, normally the same header level as `latest_changes_header`, so, if the `latest_changes_header` is `### Latest Changes`, the content for the next release below is probably something like `### 0.2.0`, then the `end_regex` should be `^### `. This is used to limit the content updated as this will read the existing sub sections and possibly update them using the labels configuration and the labels in the PR. By default it is `(^### .*)|(^## .*)` to detect a possible next header, e.g. for the license.
+* `end_regex`: A RegEx string that marks the end of this release, so it normally matches the start of the header of the next release section, at the same header level as `latest_changes_header`. By default it is `^## `, matching a release header such as `## 0.2.0`.
 * `debug_logs`: Set to `'true'` to show logs with the current settings.
 * `labels`: A JSON array of JSON objects with a `label` that you would put in each PR and the `header` that would be used in the release notes. See the example below.
-* `label_header_prefix`: A prefix to put before each label's header. This is also used to detect where the next label header starts. By default it is `#### `, so the headers will look like `#### Features`.
+* `label_header_prefix`: A prefix to put before each label's header. This is also used to detect where the next label header starts. By default it is `### `, so the headers will look like `### Features`.
 * `skip_labels`: A JSON array of label names for PRs that should not be added to the latest changes. By default, this is `["release"]`. If the same label is configured in `labels`, the `labels` configuration takes precedence and the PR is still added.
 
 ### Configuring Labels
@@ -198,7 +198,7 @@ jobs:
         end_regex: '^## '
         debug_logs: true
         # Here we use a yaml multiline string to pass a JSON array of JSON objects in a more readable way
-        # In these case we use the same default labels and the same header titles, but the headers use 3 hash symbols instead of the default of 4
+        # In this case we use the same default labels and header titles, but the headers use 4 hash symbols instead of the default of 3
         # We also add a custom last label "egg" for PRs with easter eggs.
         labels: >
           [
@@ -216,7 +216,7 @@ jobs:
           ]
         # This will be added to the start of each label's header and
         # will be used to detect existing label headers
-        label_header_prefix: '### '
+        label_header_prefix: '#### '
         # PRs with any of these labels won't be added to the latest changes
         # By default, this is ["release"]
         skip_labels: '["release"]'
@@ -254,7 +254,7 @@ And that Markdown will be shown like:
 
 * It will use the same default labels and headers plus another one for easter eggs.
 
-* It will show those section headers from labels with 3 hash symbols instead of the default of 4. And it will also find any existing header checking for that prefix (it will use a regular expression like `^### `).
+* It will show those section headers from labels with 4 hash symbols instead of the default of 3. And it will also find any existing header checking for that prefix (it will use a regular expression like `^#### `).
 
 ## Protected Branches
 

--- a/action.yml
+++ b/action.yml
@@ -13,15 +13,15 @@ inputs:
     required: false
   latest_changes_header:
     description: Header to search for in the latest changes file, this action will add the changes right after that string.
-    default: '### Latest Changes'
+    default: '## Latest Changes'
     required: false
   template_file:
     description: To override the default message with a custom Jinja2 template, use a path relative to the repo.
     required: false
     default: /app/latest_changes/latest-changes.jinja2
   end_regex:
-    description: A RegEx string that marks the end of this release, so it normally matches the start of the header of the next release section, normally the same header level as `latest_changes_header`, so, if the `latest_changes_header` is `### Latest Changes`, the content for the next release below is probably something like `### 0.2.0`, then the `end_regex` should be `^### `. By default it is `(^### .*)|(^## .*)` to detect a possible next header, e.g. for the license.
-    default: '(^### .*)|(^## .*)'
+    description: A RegEx string that marks the end of this release, so it normally matches the start of the header of the next release section, normally the same header level as `latest_changes_header`, so, if the `latest_changes_header` is `## Latest Changes`, the content for the next release below is probably something like `## 0.2.0`, then the `end_regex` should be `^## `.
+    default: '^## '
     required: false
   debug_logs:
     description: Use debug=True to enable more logging, useful to see the object shape for custom Jinja2 templates
@@ -44,8 +44,8 @@ inputs:
         {"label": "internal", "header": "Internal"}
       ]
   label_header_prefix:
-    description: A prefix to put before each label's header. This is also used to detect where the next label header starts. By default it is `#### `, so the headers will look like `#### Features`.
-    default: '#### '
+    description: A prefix to put before each label's header. This is also used to detect where the next label header starts. By default it is `### `, so the headers will look like `### Features`.
+    default: '### '
   skip_labels:
     description: A JSON array of label names for PRs that should not be added to the latest changes. If a label is also configured in labels, labels takes precedence.
     required: false

--- a/latest_changes/main.py
+++ b/latest_changes/main.py
@@ -37,9 +37,9 @@ class Settings(BaseSettings):
     github_event_name: Optional[str] = None
     input_token: SecretStr
     input_latest_changes_file: Optional[Path] = None
-    input_latest_changes_header: str = "### Latest Changes"
+    input_latest_changes_header: str = "## Latest Changes"
     input_template_file: Path = Path(__file__).parent / "latest-changes.jinja2"
-    input_end_regex: str = "(^### .*)|(^## .*)"
+    input_end_regex: str = "^## "
     input_debug_logs: Optional[bool] = False
     input_labels: List[Section] = [
         Section(label="breaking", header="Breaking Changes"),
@@ -53,7 +53,7 @@ class Settings(BaseSettings):
         Section(label="infra", header="Infrastructure"),
         Section(label="internal", header="Internal"),
     ]
-    input_label_header_prefix: str = "#### "
+    input_label_header_prefix: str = "### "
     input_skip_labels: List[str] = ["release"]
 
 

--- a/tests/test_generate_content.py
+++ b/tests/test_generate_content.py
@@ -100,6 +100,18 @@ def test_empty_latest_changes_file_is_none(monkeypatch):
     assert settings.input_latest_changes_file is None
 
 
+def test_standalone_release_notes_defaults():
+    settings = Settings(
+        github_repository="tiangolo/latest-changes",
+        github_event_path="event.json",
+        input_token="secret",
+    )
+
+    assert settings.input_latest_changes_header == "## Latest Changes"
+    assert settings.input_end_regex == "^## "
+    assert settings.input_label_header_prefix == "### "
+
+
 def test_should_skip_labels():
     assert should_skip_labels(
         labels=["release", "internal"],
@@ -122,15 +134,15 @@ def test_should_include_labels_take_precedence_over_skip_labels():
 
 def test_no_sections():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🔥 Remove config. PR [#47](https://github.com/tiangolo/latest-changes/pull/47) by [@tiangolo](https://github.com/tiangolo).
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     * 📝 Add docs. PR [#43](https://github.com/tiangolo/latest-changes/pull/43) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -153,16 +165,16 @@ def test_no_sections():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
     * 🔥 Remove config. PR [#47](https://github.com/tiangolo/latest-changes/pull/47) by [@tiangolo](https://github.com/tiangolo).
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     * 📝 Add docs. PR [#43](https://github.com/tiangolo/latest-changes/pull/43) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -174,11 +186,11 @@ def test_no_sections():
 
 def test_before_release():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -201,13 +213,13 @@ def test_before_release():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
 
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -219,15 +231,15 @@ def test_before_release():
 
 def test_existing_labels_no_label():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Features
+    ### Features
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -250,17 +262,17 @@ def test_existing_labels_no_label():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Features
+    ### Features
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -272,15 +284,15 @@ def test_existing_labels_no_label():
 
 def test_existing_labels_same_label():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Features
+    ### Features
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -305,16 +317,16 @@ def test_existing_labels_same_label():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Features
+    ### Features
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -326,15 +338,15 @@ def test_existing_labels_same_label():
 
 def test_existing_label_other_label():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Fixes
+    ### Fixes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -359,19 +371,19 @@ def test_existing_label_other_label():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Features
+    ### Features
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Fixes
+    ### Fixes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -383,15 +395,15 @@ def test_existing_label_other_label():
 
 def test_existing_label_secondary_label():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Features
+    ### Features
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -416,19 +428,19 @@ def test_existing_label_secondary_label():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Features
+    ### Features
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Fixes
+    ### Fixes
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -440,13 +452,13 @@ def test_existing_label_secondary_label():
 
 def test_no_existing_label_label():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -471,17 +483,17 @@ def test_no_existing_label_label():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Features
+    ### Features
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -493,15 +505,15 @@ def test_no_existing_label_label():
 
 def test_no_existing_label_release_label_label():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
-    #### Features
+    ### Features
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -526,19 +538,19 @@ def test_no_existing_label_release_label_label():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Features
+    ### Features
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
-    #### Features
+    ### Features
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -550,15 +562,15 @@ def test_no_existing_label_release_label_label():
 
 def test_custom_label_label():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Custom
+    ### Custom
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -583,19 +595,19 @@ def test_custom_label_label():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Custom
+    ### Custom
     
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Features
+    ### Features
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -607,17 +619,17 @@ def test_custom_label_label():
 
 def test_sectionless_content_label():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Fixes
+    ### Fixes
 
     * 🔥 Remove config. PR [#47](https://github.com/tiangolo/latest-changes/pull/47) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -642,21 +654,21 @@ def test_sectionless_content_label():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Features
+    ### Features
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Fixes
+    ### Fixes
 
     * 🔥 Remove config. PR [#47](https://github.com/tiangolo/latest-changes/pull/47) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -668,7 +680,7 @@ def test_sectionless_content_label():
 
 def test_content_above_latest_changes():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
     Here's some content.
 
@@ -676,19 +688,19 @@ def test_content_above_latest_changes():
 
     * Here's a list.
 
-    #### Features
+    ### Features
 
     These are not release notes.
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Fixes
+    ### Fixes
 
     * 🔥 Remove config. PR [#47](https://github.com/tiangolo/latest-changes/pull/47) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -713,7 +725,7 @@ def test_content_above_latest_changes():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
     Here's some content.
 
@@ -721,23 +733,23 @@ def test_content_above_latest_changes():
 
     * Here's a list.
 
-    #### Features
+    ### Features
 
     These are not release notes.
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Features
+    ### Features
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Fixes
+    ### Fixes
 
     * 🔥 Remove config. PR [#47](https://github.com/tiangolo/latest-changes/pull/47) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -749,15 +761,15 @@ def test_content_above_latest_changes():
 
 def test_multiple_labels():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Fixes
+    ### Fixes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -782,19 +794,19 @@ def test_multiple_labels():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Features
+    ### Features
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Fixes
+    ### Fixes
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -806,7 +818,7 @@ def test_multiple_labels():
 
 def test_no_latest_changes_raises():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
     Here's some content.
 
@@ -814,17 +826,17 @@ def test_no_latest_changes_raises():
 
     * Here's a list.
 
-    #### Features
+    ### Features
 
     These are not release notes.
 
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
 
-    #### Fixes
+    ### Fixes
 
     * 🔥 Remove config. PR [#47](https://github.com/tiangolo/latest-changes/pull/47) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -848,16 +860,16 @@ def test_no_latest_changes_raises():
 
 def test_changes_exist_raises():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
     * 🔥 Remove config. PR [#47](https://github.com/tiangolo/latest-changes/pull/47) by [@tiangolo](https://github.com/tiangolo).
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     * 📝 Add docs. PR [#43](https://github.com/tiangolo/latest-changes/pull/43) by [@tiangolo](https://github.com/tiangolo).
     
-    ### 0.0.3
+    ## 0.0.3
 
     * 🚚 Update Python module name. PR [#37](https://github.com/tiangolo/latest-changes/pull/37) by [@tiangolo](https://github.com/tiangolo).
     * 🐛 Fix default Jinja2 path. PR [#38](https://github.com/tiangolo/latest-changes/pull/38) by [@tiangolo](https://github.com/tiangolo).
@@ -1158,9 +1170,9 @@ def test_multiple_header_sections_label():
 
 def test_first_change_with_extra_header():
     raw_content = """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
     ## License
 
@@ -1186,11 +1198,11 @@ def test_first_change_with_extra_header():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Notes
+    # Release Notes
 
-    ### Latest Changes
+    ## Latest Changes
 
-    #### Features
+    ### Features
 
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
 
@@ -1205,17 +1217,17 @@ def test_first_change_with_extra_header():
 
 def test_first_release_existing_content_with_extra_header():
     raw_content = """
-    ## Release Note
+    # Release Note
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🔥 Remove config. PR [#47](https://github.com/tiangolo/latest-changes/pull/47) by [@tiangolo](https://github.com/tiangolo).
     
-    #### Features
+    ### Features
     
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    #### Docs
+    ### Docs
     
     * 📝 Add docs. PR [#43](https://github.com/tiangolo/latest-changes/pull/43) by [@tiangolo](https://github.com/tiangolo).
 
@@ -1243,18 +1255,18 @@ def test_first_release_existing_content_with_extra_header():
         new_content
         == inspect.cleandoc(
             """
-    ## Release Note
+    # Release Note
 
-    ### Latest Changes
+    ## Latest Changes
 
     * 🔥 Remove config. PR [#47](https://github.com/tiangolo/latest-changes/pull/47) by [@tiangolo](https://github.com/tiangolo).
     
-    #### Features
+    ### Features
     
     * Demo PR. PR [#42](https://example.com/pr/42) by [@tiangolo](https://github.com/tiangolo).
     * 🚀 Publish amd64 and arm64 versions. PR [#46](https://github.com/tiangolo/latest-changes/pull/46) by [@tiangolo](https://github.com/tiangolo).
     
-    #### Docs
+    ### Docs
     
     * 📝 Add docs. PR [#43](https://github.com/tiangolo/latest-changes/pull/43) by [@tiangolo](https://github.com/tiangolo).
 


### PR DESCRIPTION
## Summary

- dedent the default latest-changes header from `###` to `##`
- dedent generated label sections from `####` to `###`
- make `^## ` the default boundary between releases
- update the documentation and default-behavior tests
- remove redundant release-note configuration from this repository's workflow so it exercises zero-config discovery and heading behavior

## Root cause

Version 0.7.0 changed the default target from an embedded README section to a standalone `release-notes.md` file, but retained the heading defaults designed for README nesting. Existing consumers consistently use `## Latest Changes`, `###` label sections, and a `^## ` release boundary.

The three defaults must change together: if label headings are dedented without changing the boundary regex, `### Features` would be mistaken for the end of the current release.

## Impact

A standard standalone release-notes file now works with only the required token input. Explicit custom file and heading configuration remains supported.

## Validation

- 29 tests passed
- authenticated online `zizmor` completed with no findings
- `git diff --check`

The repository's existing aggregate coverage remains 82%; the test module is fully covered and this change does not reduce the existing result.

## AI Disclaimer

Codex with gpt-5.6-sol
